### PR TITLE
Fix chat fetch for cross-origin

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-directives --max-warnings 0",
+    "test": "echo \"Error: no test specified\" && exit 1",
     "preview": "vite preview",
     "clean": "rm -rf dist"
   },

--- a/src/components/chat/CoachChat.tsx
+++ b/src/components/chat/CoachChat.tsx
@@ -47,9 +47,7 @@ export default function CoachChat() {
             goal: "improve deep sleep",
             device: "Apple Watch"
           }
-        }),
-        // Add credentials to ensure cookies are sent
-        credentials: 'include'
+        })
       });
 
       if (!res.ok) {

--- a/src/hooks/useChatApi.ts
+++ b/src/hooks/useChatApi.ts
@@ -53,8 +53,7 @@ export function useChatApi() {
             goal: "improve deep sleep",
             device: "Apple Watch"
           }
-        }),
-        credentials: 'include'
+        })
       });
 
       if (!response.ok) {

--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -44,8 +44,7 @@ export async function callOpenAiFunction(prompt: string, context?: Record<string
         body: JSON.stringify({ 
           messages: [{ role: 'user', content: prompt }],
           context
-        }),
-        credentials: 'include'
+        })
       });
 
       if (!response.ok) {


### PR DESCRIPTION
## Summary
- remove `credentials: 'include'` from fetch calls that hit Supabase functions
- add missing `test` script to package.json

## Testing
- `npm run lint` *(fails: invalid option)*
- `npx eslint . --ext .ts,.tsx --report-unused-disable-directives --max-warnings 0` *(fails: cannot find module)*
- `npm run test` *(fails: Error: no test specified)*