### PR TITLE
Refine auth route utilities

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,63 @@
+import { Routes, Route, Navigate } from 'react-router-dom';
+import { SupabaseProvider } from './contexts/SupabaseContext';
+import { AuthProvider } from './contexts/AuthContext';
+import { ThemeProvider } from './contexts/ThemeContext';
+
+import Layout from './components/layout/Layout';
+import HomePage from './pages/HomePage';
+import LoginPage from './pages/auth/LoginPage';
+import SignupPage from './pages/auth/SignupPage';
+import OnboardingPage from './pages/auth/OnboardingPage';
+import DashboardPage from './pages/dashboard/DashboardPage';
+import ChatPage from './pages/chat/ChatPage';
+import SupplementsPage from './pages/supplements/SupplementsPage';
+import CheckoutPage from './pages/checkout/CheckoutPage';
+import ProfilePage from './pages/profile/ProfilePage';
+import PricingPage from './pages/PricingPage';
+import HowItWorksPage from './pages/HowItWorksPage';
+import ProtectedRoute from './components/ProtectedRoute';
+
+/**
+ * Root application component.
+ * Wraps routes with providers and applies authentication guards
+ * where necessary.
+ */
+const protectedRoutes = [
+  { path: 'dashboard', element: <DashboardPage /> },
+  { path: 'chat', element: <ChatPage /> },
+  { path: 'supplements', element: <SupplementsPage /> },
+  { path: 'checkout', element: <CheckoutPage /> },
+  { path: 'profile', element: <ProfilePage /> },
+] as const;
+
+function App(): JSX.Element {
+  return (
+    <SupabaseProvider>
+      <ThemeProvider>
+        <AuthProvider>
+          <Routes>
+            <Route path="/" element={<Layout />}>
+              <Route index element={<HomePage />} />
+              <Route path="login" element={<LoginPage />} />
+              <Route path="signup" element={<SignupPage />} />
+              <Route path="onboarding" element={<OnboardingPage />} />
+              <Route path="pricing" element={<PricingPage />} />
+              <Route path="how-it-works" element={<HowItWorksPage />} />
+              {protectedRoutes.map(({ path, element }) => (
+                <Route
+                  key={path}
+                  path={path}
+                  element={<ProtectedRoute element={element} pathname={`/${path}`} />}
+                />
+              ))}
+              <Route path="*" element={<Navigate to="/" replace />} />
+            </Route>
+          </Routes>
+        </AuthProvider>
+      </ThemeProvider>
+    </SupabaseProvider>
+  );
+}
+
+export default App;
+

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,0 +1,38 @@
+import { ReactElement } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+import useSaveRedirect from '../hooks/useSaveRedirect';
+
+export interface ProtectedRouteProps {
+  /**
+   * Element visible only to authenticated users. Typically a page
+   * component passed via the router's `element` prop.
+   */
+  element: ReactElement;
+  /** Optional path to store for redirect handling */
+  pathname?: string;
+}
+
+/**
+ * Wrapper component that ensures its children are rendered only
+ * when the user is authenticated or in demo mode. Otherwise it
+ * redirects to the login page.
+ */
+const ProtectedRoute = ({ element, pathname }: ProtectedRouteProps): ReactElement => {
+  const { user, loading, isDemo } = useAuth();
+  const location = useLocation();
+  // Save the requested path if the user is not authenticated.
+  useSaveRedirect(pathname ?? location.pathname);
+
+  if (loading) {
+    return <div className="flex h-screen items-center justify-center">Loading...</div>;
+  }
+
+  if (!user && !isDemo) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return element;
+};
+
+export default ProtectedRoute;

--- a/src/hooks/useSaveRedirect.tsx
+++ b/src/hooks/useSaveRedirect.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+
+/**
+ * Persists the desired navigation target when an unauthenticated
+ * user attempts to access a protected route. The value is stored
+ * in session storage so it can be used after login.
+ */
+const useSaveRedirect = (path?: string): void => {
+  const { user, loading, isDemo } = useAuth();
+  const location = useLocation();
+  const target = path ?? location.pathname;
+
+  useEffect(() => {
+    if (!user && !loading && !isDemo) {
+      sessionStorage.setItem('redirectUrl', target);
+    }
+  }, [user, loading, isDemo, target]);
+};
+
+export default useSaveRedirect;


### PR DESCRIPTION
## Summary
- refine `useSaveRedirect` to accept optional path and avoid extraneous dependencies
- update `ProtectedRoute` to take an element and optional pathname
- simplify `App` by mapping over a typed list of protected routes

## Testing
- `npm run lint` *(fails: Could not read package.json)*
