### PR TITLE
Add npm test placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,16 @@ supabase secrets set OPENAI_API_KEY=your-openai-api-key
 /utils          // Utility functions
 ```
 
+## Testing
+
+The project currently does not include automated tests. Running `npm run test` will
+output a placeholder message and exit with status code `1`:
+
+```bash
+npm run test
+# => "Error: no test specified"
+```
+
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-directives --max-warnings 0",
+    "test": "echo \"Error: no test specified\" && exit 1",
     "preview": "vite preview",
     "clean": "rm -rf dist"
   },


### PR DESCRIPTION
## Summary
- add `test` script to `package.json`
- document npm test behavior in README

## Testing
- `npm run lint` *(fails: invalid option)*
- `npm run test`