### PR TITLE
Add centralized ProtectedRoute component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,6 @@
-import { useEffect } from 'react';
-import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom';
 import { SupabaseProvider } from './contexts/SupabaseContext';
-import { AuthProvider, useAuth } from './contexts/AuthContext';
+import { AuthProvider } from './contexts/AuthContext';
 import { ThemeProvider } from './contexts/ThemeContext';
 
 import Layout from './components/layout/Layout';
@@ -16,30 +15,9 @@ import CheckoutPage from './pages/checkout/CheckoutPage';
 import ProfilePage from './pages/profile/ProfilePage';
 import PricingPage from './pages/PricingPage';
 import HowItWorksPage from './pages/HowItWorksPage';
+import ProtectedRoute from './components/auth/ProtectedRoute';
 
-// Protected route component
-const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
-  const { user, loading, isDemo } = useAuth();
-  const location = useLocation();
-  
-  useEffect(() => {
-    if (!user && !loading && !isDemo) {
-      sessionStorage.setItem('redirectUrl', location.pathname);
-    }
-  }, [user, loading, isDemo, location]);
-  
-  if (loading) {
-    return <div className="flex h-screen items-center justify-center">Loading...</div>;
-  }
-  
-  if (!user && !isDemo) {
-    return <Navigate to="/login" replace />;
-  }
-  
-  return <>{children}</>;
-};
-
-function App() {
+function App(): JSX.Element {
   return (
     <SupabaseProvider>
       <ThemeProvider>

--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -1,0 +1,26 @@
+import { Navigate } from 'react-router-dom';
+import { useAuthGuard } from '../../hooks/useAuthGuard';
+import useSaveRedirect from '../../hooks/useSaveRedirect';
+
+interface ProtectedRouteProps {
+  children: JSX.Element;
+}
+
+const ProtectedRoute = ({ children }: ProtectedRouteProps): JSX.Element => {
+  const { isAuthenticated, isLoading } = useAuthGuard();
+  useSaveRedirect(isAuthenticated);
+
+  if (isLoading) {
+    return (
+      <div className="flex h-screen items-center justify-center">Loading...</div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return children;
+};
+
+export default ProtectedRoute;

--- a/src/hooks/useSaveRedirect.tsx
+++ b/src/hooks/useSaveRedirect.tsx
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export default function useSaveRedirect(isAuthenticated: boolean): void {
+  const location = useLocation();
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      sessionStorage.setItem('redirectUrl', location.pathname);
+    }
+  }, [isAuthenticated, location]);
+}


### PR DESCRIPTION
## Summary
- centralize auth guard in `ProtectedRoute` component
- preserve redirect intent with new `useSaveRedirect` hook
- simplify `App.tsx` and use `ProtectedRoute`

## Testing
- `npm run lint` *(fails: Invalid option '--report-unused-directives')*
- `npm run test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_683bc3a08b88832889b94da2ef1581b3