### PR TITLE
Fix lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "lint": "eslint . --ext ts,tsx --report-unused-directives --max-warnings 0",
+    "lint": "eslint . --ext .ts,.tsx --report-unused-disable-directives --max-warnings 0",
     "test": "echo \"Error: no test specified\" && exit 1",
     "preview": "vite preview",
     "clean": "rm -rf dist"


### PR DESCRIPTION
## Summary
- correct the lint script to use `--report-unused-disable-directives`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683bc64f214c8328901b8c2d0b9cd554