### PR TITLE
Fix useSaveRedirect export conflict

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,6 @@
+export * from './useAuthGuard';
+export * from './useChatApi';
+export * from './useKeyboardShortcut';
+export * from './useOpenAi';
+export * from './useSaveRedirect';
+export * from './useSupplementFilter';

--- a/src/hooks/useSaveRedirect.tsx
+++ b/src/hooks/useSaveRedirect.tsx
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+
+/**
+ * Persists the user's intended destination when they hit a protected route.
+ * Stores the current pathname in sessionStorage if unauthenticated.
+ */
+export function useSaveRedirect() {
+  const { user, loading, isDemo } = useAuth();
+  const location = useLocation();
+
+  useEffect(() => {
+    if (!user && !loading && !isDemo) {
+      sessionStorage.setItem('redirectUrl', location.pathname);
+    }
+  }, [user, loading, isDemo, location.pathname]);
+}
+

--- a/src/hooks/useSupplementFilter.tsx
+++ b/src/hooks/useSupplementFilter.tsx
@@ -1,0 +1,21 @@
+import { useMemo } from 'react';
+import type { Supplement } from '../types/supplements';
+
+/**
+ * Provides a memoized filter for supplement arrays.
+ * @param supplements - Array of supplements to filter
+ * @param query - Search string to match against name and description
+ * @returns Filtered list of supplements
+ */
+export function useSupplementFilter(supplements: Supplement[], query: string) {
+  const normalized = query.toLowerCase();
+
+  return useMemo(() => {
+    if (!normalized) return supplements;
+    return supplements.filter(
+      (s) =>
+        s.name.toLowerCase().includes(normalized) ||
+        s.description.toLowerCase().includes(normalized)
+    );
+  }, [supplements, normalized]);
+}


### PR DESCRIPTION
## Summary
- tidy up `useSaveRedirect` implementation after merge conflict

## Testing
- `npm run lint` *(fails: Invalid option '--report-unused-directives')*
- `npm run test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_683bc39dde9c832885d3538fd1ebb2d0