### PR TITLE
Update README with lint/test docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,20 @@ supabase secrets set OPENAI_API_KEY=your-openai-api-key
 /utils          // Utility functions
 ```
 
+### Linting and Testing
+
+Run ESLint to check the codebase:
+
+```bash
+npm run lint
+```
+
+Run the placeholder test script:
+
+```bash
+npm run test
+```
+
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.
@@ -95,7 +109,3 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.
-=======
-# BWMIDO
-version 2.0
->>>>>>> 47e4a56b7da159707f2de74477cec405b7275786

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "lint": "eslint . --ext ts,tsx --report-unused-directives --max-warnings 0",
+    "lint": "eslint . --ext .ts,.tsx --report-unused-disable-directives --max-warnings 0",
+    "test": "echo \"Error: no test specified\" && exit 1",
     "preview": "vite preview",
     "clean": "rm -rf dist"
   },


### PR DESCRIPTION
## Summary
- document lint and test scripts in README
- remove leftover merge markers
- provide clean instructions for script usage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_683bc383963c8328a1bdd47eaea6c991