### PR TITLE
Add env example with all API keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,26 @@
+# Example environment configuration for Biowell
+
+# Supabase credentials
+VITE_SUPABASE_URL=https://your-supabase-url
+VITE_SUPABASE_ANON_KEY=your-anon-key
+VITE_SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+VITE_SUPABASE_SERVICE_ROLE_SECRET=your-service-role-secret
+
+# OpenAI
+OPENAI_API_KEY=your-openai-api-key
+VITE_OPENAI_KEY=your-openai-key
+
+# ElevenLabs
+VITE_ELEVENLABS_API_KEY=your-elevenlabs-key
+
+# GitHub
+VITE_GITHUB_TOKEN=your-github-token
+
+# Stackblitz
+VITE_STACKBLITZ_API_KEY=your-stackblitz-key
+
+# Captcha secret used in AuthContext
+VITE_CAPTCHA_SECRET_KEY=your-captcha-secret
+
+# Stripe publishable key if using payments
+VITE_STRIPE_PUBLISHABLE_KEY=your-stripe-publishable-key

--- a/README.md
+++ b/README.md
@@ -44,11 +44,19 @@ cd biowell-ai
 npm install
 ```
 
-3. Create a `.env` file based on `.env.example` and add your Supabase credentials:
+3. Create a `.env` file based on `.env.example` and fill in your API keys:
 
 ```
 VITE_SUPABASE_URL=your-supabase-url
 VITE_SUPABASE_ANON_KEY=your-supabase-anon-key
+VITE_SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+VITE_SUPABASE_SERVICE_ROLE_SECRET=your-service-role-secret
+OPENAI_API_KEY=your-openai-api-key
+VITE_OPENAI_KEY=your-openai-key
+VITE_ELEVENLABS_API_KEY=your-elevenlabs-key
+VITE_GITHUB_TOKEN=your-github-token
+VITE_STACKBLITZ_API_KEY=your-stackblitz-key
+VITE_CAPTCHA_SECRET_KEY=your-captcha-secret
 VITE_STRIPE_PUBLISHABLE_KEY=your-stripe-publishable-key
 ```
 


### PR DESCRIPTION
## Summary
- document environment variables in new `.env.example`
- update README with expanded env setup instructions

## Testing
- `npm run lint` *(fails: parsing errors)*
- `npm run test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68447e73fa848328b4f6d2cef1f7303f