### PR TITLE
Fix netlify config parse error

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,10 +2,11 @@
   command = "npm run build"
   publish = "dist"
 
+  [build.environment]
+    NODE_VERSION = "18"
+
 [[redirects]]
   from = "/*"
   to = "/index.html"
   status = 200
 
-[build.environment]
-  NODE_VERSION = "18"


### PR DESCRIPTION
## Summary
- restructure `netlify.toml` to keep `[build.environment]` within the build table

## Testing
- `npm run lint` *(fails: parsing errors)*
- `npm run test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684481f06bb48328bee197d95028d7a4