### PR TITLE
Add node-fetch dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "react-markdown": "^9.0.1",
     "react-router-dom": "^6.21.1",
     "tailwind-merge": "^3.2.0",
-    "zustand": "^4.4.7"
+    "zustand": "^4.4.7",
+    "node-fetch": "^3.3.2"
   },
   "devDependencies": {
     "@types/node": "^20.10.6",


### PR DESCRIPTION
## Summary
- add `node-fetch` to package dependencies to resolve missing module error

## Testing
- `npm run lint` *(fails: Parsing errors)*
- `npm run test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68497d9aa344832881f661a42bad1e61