### PR TITLE
Add redirectPath support to ProtectedRoute

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,6 @@ import CheckoutPage from './pages/checkout/CheckoutPage';
 import ProfilePage from './pages/profile/ProfilePage';
 import PricingPage from './pages/PricingPage';
 import HowItWorksPage from './pages/HowItWorksPage';
-import { ProtectedRoute } from './components/auth/ProtectedRoute';
 
 function App(): JSX.Element {
   return (

--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -1,14 +1,20 @@
-import { Navigate, useLocation } from 'react-router-dom';
+import { Navigate } from 'react-router-dom';
 import { useAuthGuard } from '../../hooks/useAuthGuard';
 import useSaveRedirect from '../../hooks/useSaveRedirect';
 
 interface ProtectedRouteProps {
   children: React.ReactNode;
+  /**
+   * Path to redirect unauthenticated users to. Defaults to "/login".
+   */
+  redirectPath?: string;
 }
 
-const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
-  const { isAuthenticated, isLoading, isDemo } = useAuthGuard(); // Make sure your hook returns isDemo if needed
-  const location = useLocation();
+const ProtectedRoute = ({
+  children,
+  redirectPath = '/login',
+}: ProtectedRouteProps) => {
+  const { isAuthenticated, isLoading, isDemo } = useAuthGuard(redirectPath);
 
   // Save redirect URL if not authenticated and not in demo mode
   useSaveRedirect(isAuthenticated);
@@ -26,7 +32,7 @@ const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
   }
 
   if (!isAuthenticated && !isDemo) {
-    return <Navigate to="/login" replace />;
+    return <Navigate to={redirectPath} replace />;
   }
 
   return <>{children}</>;


### PR DESCRIPTION
## Summary
- add `redirectPath` prop to `ProtectedRoute`
- clean up `ProtectedRoute` imports and ensure default export usage
- remove unused named import in `App.tsx`

## Testing
- `npm run lint` *(fails: parsing errors)*
- `npm run test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684d0004c0808328b02890ad7ba75b59