### PR TITLE
Fix nested @apply in subproject CSS

### DIFF
--- a/biowell deploy/src/index.css
+++ b/biowell deploy/src/index.css
@@ -98,11 +98,11 @@
   }
   
   .btn-primary {
-    @apply btn bg-primary text-white shadow-lg shadow-primary/25 hover:bg-primary-dark hover:shadow-xl hover:shadow-primary/30 active:scale-[0.98];
+    @apply inline-flex items-center justify-center gap-2 rounded-xl px-6 py-3 font-medium transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40 bg-primary text-white shadow-lg shadow-primary/25 hover:bg-primary-dark hover:shadow-xl hover:shadow-primary/30 active:scale-[0.98];
   }
-  
+
   .btn-outline {
-    @apply btn border-2 border-[hsl(var(--color-border))] bg-transparent text-text shadow-sm hover:bg-[hsl(var(--color-card-hover))] hover:shadow-md active:scale-[0.98];
+    @apply inline-flex items-center justify-center gap-2 rounded-xl px-6 py-3 font-medium transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40 border-2 border-[hsl(var(--color-border))] bg-transparent text-text shadow-sm hover:bg-[hsl(var(--color-card-hover))] hover:shadow-md active:scale-[0.98];
   }
 
   .btn-sm {


### PR DESCRIPTION
## Summary
- remove nested `@apply` usage from `biowell deploy` CSS to avoid Tailwind build errors

## Testing
- `npm run lint`
- `npm run test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684d02fa56dc83288de748c134de3d7e