### PR TITLE
Fix syntax error in onboarding step config

### DIFF
--- a/src/pages/onboarding/steps/config.ts
+++ b/src/pages/onboarding/steps/config.ts
@@ -1,7 +1,5 @@
-codex/introduce-modular-onboarding-steps
 import { ComponentType } from 'react';
-=======
-main
+
 import WelcomeStep from './WelcomeStep';
 import PersonalInfoStep from './PersonalInfoStep';
 import HealthGoalsStep from './HealthGoalsStep';
@@ -9,7 +7,6 @@ import LifestyleStep from './LifestyleStep';
 import WearablesStep from './WearablesStep';
 import CompletionStep from './CompletionStep';
 
-codex/introduce-modular-onboarding-steps
 export interface StepConfig {
   title: string;
   component: ComponentType<any>;
@@ -21,17 +18,7 @@ const steps: StepConfig[] = [
   { title: 'Health Goals', component: HealthGoalsStep },
   { title: 'Lifestyle', component: LifestyleStep },
   { title: 'Wearables', component: WearablesStep },
-  { title: 'Complete', component: CompletionStep }
+  { title: 'Complete', component: CompletionStep },
 ];
 
 export default steps;
-=======
-export default [
-  WelcomeStep,
-  PersonalInfoStep,
-  HealthGoalsStep,
-  LifestyleStep,
-  WearablesStep,
-  CompletionStep,
-];
-main


### PR DESCRIPTION
## Summary
- clean up onboarding `steps/config.ts` to remove stray merge markers

## Testing
- `npm run lint` *(fails: Invalid option '--report-unused-directives')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e5f34fb7c8328ba5508513097d08f