### PR TITLE
Disable Netlify secret scanning

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,7 @@
 
   [build.environment]
     NODE_VERSION = "20"
+    SECRETS_SCAN_SMART_DETECTION_ENABLED = "false"
 
 [[redirects]]
   from = "/*"


### PR DESCRIPTION
## Summary
- disable Netlify secret scanning via `SECRETS_SCAN_SMART_DETECTION_ENABLED = "false"`

## Testing
- `npm run lint` *(fails: Parsing errors)*
- `npm run test` *(fails: vitest not found)*


------
https://chatgpt.com/codex/tasks/task_e_685149a243808328902890e4676847e2