### PR TITLE
Add metrics advice edge function

### DIFF
--- a/supabase/functions/__tests__/metrics-advice.test.ts
+++ b/supabase/functions/__tests__/metrics-advice.test.ts
@@ -1,0 +1,44 @@
+import { handleRequest } from '../metrics-advice/index';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+beforeEach(() => {
+  // @ts-ignore
+  globalThis.Deno = {
+    env: {
+      get: (key: string) => {
+        if (key === 'SUPABASE_URL') return 'http://localhost';
+        if (key === 'SUPABASE_SERVICE_ROLE_KEY') return 'key';
+        if (key === 'OPENAI_API_KEY') return 'openai';
+        return '';
+      },
+    },
+  } as any;
+
+  vi.stubGlobal('fetch', async (input: RequestInfo) => {
+    const url = typeof input === 'string' ? input : input instanceof Request ? input.url : '';
+    if (url.includes('openai.com')) {
+      return new Response(
+        JSON.stringify({ choices: [{ message: { content: 'ok' } }] }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+    // supabase response
+    return new Response(
+      JSON.stringify({ data: { sleep_hours: 7, deep_sleep_minutes: 90, daily_steps: 10000, calories_burned: 2000, bmi: 23, activity_goal: 'Lose weight' }, error: null }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    );
+  });
+});
+
+describe('metrics-advice', () => {
+  it('returns 200 with a reply', async () => {
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: '1', userQuestion: 'Hi?' }),
+    });
+
+    const res = await handleRequest(req);
+    expect(res.status).toBe(200);
+  });
+});

--- a/supabase/functions/metrics-advice/index.ts
+++ b/supabase/functions/metrics-advice/index.ts
@@ -1,0 +1,70 @@
+import { createClient } from "npm:@supabase/supabase-js";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization, apikey",
+  "Access-Control-Max-Age": "86400",
+  "Access-Control-Allow-Credentials": "true",
+};
+
+export async function handleRequest(req: Request): Promise<Response> {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 200, headers: corsHeaders });
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get("SUPABASE_URL") as string;
+    const supabaseKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") as string;
+    const openaiApiKey = Deno.env.get("OPENAI_API_KEY") as string;
+
+    if (!supabaseUrl || !supabaseKey || !openaiApiKey) {
+      throw new Error("Missing configuration");
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseKey);
+    const { userId, userQuestion } = await req.json();
+
+    const { data: userMetrics, error } = await supabase
+      .from("user_metrics")
+      .select("*")
+      .eq("user_id", userId)
+      .single();
+
+    if (error) {
+      return new Response(
+        JSON.stringify({ error: error.message }),
+        { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    const prompt = `\n  User metrics:\n  - Sleep hours: ${userMetrics.sleep_hours}\n  - Deep sleep: ${userMetrics.deep_sleep_minutes} minutes\n  - Daily steps: ${userMetrics.daily_steps}\n  - Calories burned: ${userMetrics.calories_burned}\n  - BMI: ${userMetrics.bmi}\n  - Activity goal: ${userMetrics.activity_goal}\n\n  User question: "${userQuestion}"\n\n  Provide clear, actionable, personalized recommendations based on the provided metrics.\n  `;
+
+    const openaiResponse = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${openaiApiKey}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-4-turbo",
+        messages: [{ role: "user", content: prompt }],
+        max_tokens: 300,
+      }),
+    });
+
+    const gptData = await openaiResponse.json();
+
+    return new Response(
+      JSON.stringify({ reply: gptData.choices[0].message.content }),
+      { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  } catch (err: any) {
+    return new Response(
+      JSON.stringify({ error: err.message || "Internal server error" }),
+      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  }
+}
+
+Deno.serve(handleRequest);


### PR DESCRIPTION
## Summary
- add `metrics-advice` Supabase Edge Function that generates recommendations via OpenAI based on user metrics
- include corresponding test

## Testing
- `npm run lint` *(fails: Parsing errors)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bd235286483289736d7f578948403